### PR TITLE
Fixed the raw socket leak while trying to find eligible interfaces

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -68,5 +68,7 @@ func echo(address string, ip *net.IP) (int, error) {
 		err = errors.New(errId)
 		ret = ERROR
 	}
+
+	p.Stop()
 	return ret, err
 }


### PR DESCRIPTION
When any interface errors out because it received an unexpected ICMP reply like TTL exceeded message then
the the receiveICMP() inside fastping package does not end and had to be explicitly stopped. Added Stop() call when we have received any kind of response that we can work with.

Signed-off-by: Jana Radhakrishnan mrjana@socketplane.io
